### PR TITLE
fixes for copy and checkAttribute

### DIFF
--- a/MOS.zdsproj
+++ b/MOS.zdsproj
@@ -37,6 +37,7 @@
 <file filter-key="">.\\src_umm_malloc\\umm_malloc.c</file>
 <file filter-key="">.\\src\\mos_sysvars.c</file>
 <file filter-key="">.\\src\\mos_file.c</file>
+<file filter-key="">.\\src\\utils.c</file>
 </files>
 
 <!-- configuration information -->

--- a/src/mos.c
+++ b/src/mos.c
@@ -55,6 +55,7 @@
 #include "umm_malloc.h"
 #include "mos_sysvars.h"
 #include "mos_file.h"
+#include "utils.h"
 #if DEBUG > 0
 # include "tests.h"
 #endif /* DEBUG */
@@ -1633,7 +1634,7 @@ extern void sysvars[];
 // - MOS error code
 //
 int mos_cmdMEM(char * ptr) {
-	int try_len = HEAP_LEN;
+	uint24_t try_len = getLargestFreeHeapFragment();
 
 	printf("ROM      &000000-&01ffff     %2d%% used\r\n", ((int)_low_romdata) / 1311);
 	printf("USER:LO  &%06x-&%06x %6d bytes\r\n", 0x40000, (int)_low_data-1, (int)_low_data - 0x40000);
@@ -1643,16 +1644,6 @@ int mos_cmdMEM(char * ptr) {
 	printf("STACK24  &%06x-&%06x %6d bytes\r\n", (int)_stack - SPL_STACK_SIZE, _stack-1, SPL_STACK_SIZE);
 	printf("USER:HI  &b7e000-&b7ffff   8192 bytes\r\n");
 	printf("\r\n");
-
-	// find largest kmalloc contiguous region
-	for (; try_len > 0; try_len-=8) {
-		void *p = umm_malloc(try_len);
-		if (p) {
-			umm_free(p);
-			break;
-		}
-	}
-
 	printf("Largest free MOS:HEAP fragment: %d bytes\r\n", try_len);
 	printf("Sysvars at &%06x\r\n", sysvars);
 	printf("\r\n");

--- a/src/mos_file.c
+++ b/src/mos_file.c
@@ -7,6 +7,7 @@
 
 #include "mos_file.h"
 #include "mos_sysvars.h"
+#include "utils.h"
 
 // Check if a path is a directory - path must be resolved
 uint8_t isDirectory(char *path) {
@@ -128,7 +129,7 @@ bool checkAttribute(BYTE attribute, BYTE flags) {
 	if (matchAll) {
 		// top bit set means we are looking for a complete flag/attribute match
 		// i.e. all requested attributes must be set.  extra attributes that may be set are ignored
-		return (flags & attribute == flags);
+		return ((flags & attribute) == flags);
 	}
 	// otherwise we are excluding if one of the flags is set
 	return !(flags & attribute);
@@ -492,7 +493,15 @@ int copyFile(char * source, char * dest) {
 	UINT br, bw;
 	BYTE * buffer;
 
-	buffer = umm_malloc(1024);
+	// Work out the largest sensible/efficient buffer size for copying
+	// taking the largest free size, and rounding to a multiple of 512 (the typical cluster size)
+	uint24_t bufferSize = getLargestFreeHeapFragment();
+	if (bufferSize > 512) {
+		// Round down to a multiple of 512, avoiding zeroing the size
+		bufferSize = bufferSize & 0xfffe00;
+	}
+
+	buffer = umm_malloc(bufferSize);
 	if (!buffer) {
 		return MOS_OUT_OF_MEMORY;
 	}
@@ -502,7 +511,7 @@ int copyFile(char * source, char * dest) {
 		fr = f_open(&dst, dest, FA_WRITE | FA_CREATE_NEW);
 		if (fr == FR_OK) {
 			while (1) {
-				fr = f_read(&src, buffer, sizeof(buffer), &br);
+				fr = f_read(&src, buffer, bufferSize, &br);
 				if (fr != FR_OK || br == 0) {
 					break;
 				}

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,0 +1,15 @@
+#include "utils.h"
+
+uint24_t getLargestFreeHeapFragment() {
+	uint24_t try_len = HEAP_LEN;
+
+	// find largest kmalloc contiguous region
+	for (; try_len > 0; try_len-=8) {
+		void *p = umm_malloc(try_len);
+		if (p) {
+			umm_free(p);
+			break;
+		}
+	}
+	return try_len;
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,9 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+#include "defines.h"
+#include "umm_malloc.h"
+
+uint24_t	getLargestFreeHeapFragment();
+
+#endif // UTILS_H


### PR DESCRIPTION
a bug was discovered in the `copyFile` function whereby it was using just 3 bytes of the buffer it had allocated for copying data.  this has now been fixed, and it will now use the largest practical buffer size for copying

also includes a fix to logic inside `checkAttribute` where operator precedence was meaning when “match all” was set the logic would not work correctly (thanks to @xianpinder for spotting this, letting me know what the problem was, and the fix)