### PR TITLE
fixes for tab completion and alias resolution

### DIFF
--- a/src/mos.c
+++ b/src/mos.c
@@ -483,15 +483,19 @@ int mos_exec(char * buffer, BOOL in_mos) {
 			// Skip alias expansion for commands that start with %
 			commandPtr++;
 			cmdLen--;
-		} else {
+		} else if (memchr(commandPtr, '*', cmdLen) == NULL && memchr(commandPtr, '#', cmdLen) == NULL) {
 			// Check if this command has an alias
-			char * aliasToken = umm_malloc(cmdLen + 7);
+			// Skips commands containing `*` or `#` as they aren't valid command characters
+			char * aliasToken = umm_malloc(cmdLen + 8);
 			if (aliasToken == NULL) {
 				return MOS_OUT_OF_MEMORY;
 			}
-			sprintf(aliasToken, "Alias$%.*s", cmdLen, commandPtr);
-			if (cmdLen > 1 && aliasToken[strlen(aliasToken) - 1] == '.') {
-				aliasToken[strlen(aliasToken) - 1] = '*';
+            if (commandPtr[cmdLen - 1] == '.' && cmdLen > 1) {
+				// command ends with a dot which we treat as an abbreviation
+				// use `#*` in the wildcard to ensure matches extend the current term
+				sprintf(aliasToken, "Alias$%.*s#*", cmdLen - 1, commandPtr);
+			} else {
+				sprintf(aliasToken, "Alias$%.*s", cmdLen, commandPtr);
 			}
 			result = mos_execAlias(aliasToken, ptr, NULL, in_mos, NULL);
 			umm_free(aliasToken);

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -332,7 +332,7 @@ BYTE handleHotkey(UINT8 fkey, char * buffer, int bufferLength, int insertPos, in
 
 // Find the start of a term in the buffer
 //
-const char * findTermStart(char * buffer, int insertPos, UINT16 flags) {
+const char * findTermStart(char * buffer, int insertPos, UINT16 flags, int * termLength) {
 	// flags potentially allow us to change behaviour
 	// for now we are hard-coded for the CLI, so first we skip leading `*` and ` ` characters
 	char * termPtr;
@@ -360,6 +360,13 @@ const char * findTermStart(char * buffer, int insertPos, UINT16 flags) {
 	}
 	if (*termPtr == 0) {
 		// No term found
+		return NULL;
+	}
+
+	// Compute term length and reject terms containing '*' wildcard,
+	// as the insertString offset logic cannot handle wildcard terms
+	*termLength = buffer + insertPos - termPtr;
+	if (memchr(termPtr, '*', *termLength) != NULL) {
 		return NULL;
 	}
 
@@ -521,13 +528,12 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT16 flags) {
 								int termLength = 0;
 								int resolveLength;
 
-								termStart = findTermStart(buffer, insertPos, flags);
+								termStart = findTermStart(buffer, insertPos, flags, &termLength);
 								if (termStart == NULL) {
 									// no term found, so beep and exit
 									putch(0x07); // Beep
 									break;
 								}
-								termLength = buffer + insertPos - termStart;
 
 								// our term is from termStart to buffer + insertPos
 								// if the term had a leading double-quote, that is one character _before_ termStart
@@ -548,11 +554,16 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT16 flags) {
 										break;
 									}
 
-									sprintf(searchTerm, "Alias$%.*s*", termLength, termStart);
-									if (getSystemVariable(searchTerm, &var) == 0) {
-										// Matching alias found
-										matched = true;
-										insertPos = insertString(buffer, var->label + 6, strlen(var->label + 6), termLength, insertPos, len, limit, ' ');
+									// Alias matching here uses plain `*` wildcard to allow auto-complete to recognise current term
+									// is complete and just add a space
+									// Skip alias lookup if term contains '#' as it would be treated as a wildcard by pmatch
+									if (memchr(termStart, '#', termLength) == NULL) {
+										sprintf(searchTerm, "Alias$%.*s*", termLength, termStart);
+										if (getSystemVariable(searchTerm, &var) == 0) {
+											// Matching alias found
+											matched = true;
+											insertPos = insertString(buffer, var->label + 6, strlen(var->label + 6), termLength, insertPos, len, limit, ' ');
+										}
 									}
 
 									if (!matched) {
@@ -569,6 +580,7 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT16 flags) {
 									if (!matched) {
 										// Find command in runpath, or given path - omitting hidden/system files
 										// TODO think more on this `:` detection once we support runtypes
+										// Wildcard is a plain `*` to allow current term to be recognised as complete
 										if (memchr(termStart, ':' , termLength) != NULL) {
 											sprintf(searchTerm, "%.*s*.bin", termLength, termStart);
 										} else {
@@ -599,6 +611,7 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT16 flags) {
 								}
 
 								sprintf(searchTerm, "%.*s*", termLength, termStart);
+
 								resolveLength = bufferLength;
 								// Find file, omitting hidden/system files
 								fr = resolvePath(searchTerm, path, &resolveLength, NULL, NULL, AM_HID | AM_SYS | RESOLVE_OMIT_EXPAND);

--- a/src/mos_sysvars.c
+++ b/src/mos_sysvars.c
@@ -1027,19 +1027,10 @@ char * expandVariable(t_mosSystemVariable * var, bool showWriteOnly) {
 }
 
 // expandVariableToken is used for internal variable expansion
-// if it's given a token ending in a wildcard then it's been used to match an abbreviated command
-// so we need to ensure that we _don't_ match to variables with names that only match the non-wildcard part of the token
 char * expandVariableToken(char * token) {
 	t_mosSystemVariable * var = NULL;
-	int tokenLen = strlen(token);
 	int result = getSystemVariable(token, &var);
 	if (result != 0) {
-		return NULL;
-	}
-	// if the token ends in a `*` then it's an abbreviation
-	// and we should reject variables whose names are shorter than the token
-	// as they would have only matched the non-wildcard part of the token
-	if ((token[tokenLen - 1] == '*') && (strlen(var->label) < tokenLen)) {
 		return NULL;
 	}
 	return expandVariable(var, false);

--- a/src/strings.c
+++ b/src/strings.c
@@ -150,7 +150,7 @@ int pmatch(const char *pattern, const char *string, uint8_t flags) {
 		char patternChar = caseInsensitive ? tolower(*pattern) : *pattern;
 		char stringChar = caseInsensitive ? tolower(*string) : *string;
 
-		if ((*pattern == '#' && !disableHash) || patternChar == stringChar) {
+		if ((!disableHash && *pattern == '#' && *string != '\0') || patternChar == stringChar) {
 			return pmatch(pattern + 1, string + 1, flags);
 		}
 


### PR DESCRIPTION
tab completion is now disabled when the current token we’re trying to complete includes a `*`, as wildcard matching cannot be practically supported in a manner that will work as expected

this fixes issue #182 whereby tab-completion in a directory that contains `!Boot.obey` and the input line is `dir *.o` would complete the string in a rather incorrect manner to `dir *.oot.obey`.  whilst simply disabling auto-complete here is not exactly ideal, it’s an acceptable compromise without extensive rewrites to the tab-completion system

also has fixes to alias resolution:
* alias lookup inside mos_exec now rejects command strings containing `#` or `*` which the variable system treats as wildcard characters, and are not valid command characers.  this better reflects RISC OS behaviour.
* when mos_exec is looking up an alias for an abbreviated command it now uses a lookup token ending in `#*` instead of just `*` to ensure that any matched alias extends the base token.  the hacky functionality previously added inside `expandVariableToken` to provide equivalent functionality has been deleted as it’s no longer necessary
* an issue introduced by earlier alias resolution changes that meant `*.` was being interpreted as “first matching variable beginning with `Alias$`” has been fixed.  `*.` now works again, and as an added bonus `Alias$.` can now be defined and will be interpreted correctly

tab-completion for aliases similarly will be bypassed when the term being matched includes a `#` character

the revised approach inside mos_exec for looking up abbreviated aliases revealed a bug in how `pmatch` was handling the `#` wildcard.  this was preventing the new alias lookup from working correctly as a `#` was incorrectly matching at the end of a target string, rather than insisting there should be another character.  this has now been fixed