### PR TITLE
updateSystemVariable improved memory

### DIFF
--- a/src/mos.c
+++ b/src/mos.c
@@ -490,7 +490,7 @@ int mos_exec(char * buffer, BOOL in_mos) {
 			if (aliasToken == NULL) {
 				return MOS_OUT_OF_MEMORY;
 			}
-            if (commandPtr[cmdLen - 1] == '.' && cmdLen > 1) {
+			if (commandPtr[cmdLen - 1] == '.' && cmdLen > 1) {
 				// command ends with a dot which we treat as an abbreviation
 				// use `#*` in the wildcard to ensure matches extend the current term
 				sprintf(aliasToken, "Alias$%.*s#*", cmdLen - 1, commandPtr);

--- a/src/mos_sysvars.c
+++ b/src/mos_sysvars.c
@@ -120,14 +120,20 @@ int updateSystemVariable(t_mosSystemVariable * var, MOSVARTYPE type, void * valu
 
 	var->type = type;
 	if (type == MOS_VAR_MACRO || type == MOS_VAR_STRING) {
-		char * newValue = mos_strdup(value);
-		if (newValue == NULL) {
-			return MOS_OUT_OF_MEMORY;
-		}
+		int len = strlen(value) + 1;
 		if (oldType == MOS_VAR_MACRO || oldType == MOS_VAR_STRING) {
-			umm_free(var->value);
+			char * newValue = umm_realloc(var->value, len);
+			if (newValue == NULL) {
+				return MOS_OUT_OF_MEMORY;
+			}
+			var->value = newValue;
+		} else {
+			var->value = umm_malloc(len);
+			if (var->value == NULL) {
+				return MOS_OUT_OF_MEMORY;
+			}
 		}
-		var->value = newValue;
+		strcpy(var->value, value);
 	} else {
 		if (oldType == MOS_VAR_MACRO || oldType == MOS_VAR_STRING) {
 			umm_free(var->value);


### PR DESCRIPTION
changes updating a system variable value to use `umm_realloc` instead of `mos_strdup` (when possible) which should help reduce heap fragmentation

thanks to @xianpinder for the updated function